### PR TITLE
Update README.md to fix Web3j link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -33,4 +33,4 @@ Project specific:
 - [Hyperledger Solang](https://github.com/hyperledger-solang)
 - [Lockness](https://github.com/LFDT-Lockness)
 - [Smoot](https://github.com/LFDT-Smoot)
-- [Web3J](https://github.com/hyperledger-web3j)
+- [Web3J](https://github.com/LFDT-web3j)


### PR DESCRIPTION
Current Web3j link goes to https://github.com/hyperledger-web3j, which is someone's personal repo (and should be notified they cannot use Hyperledger or Web3j in their name) 

Corrected the link to https://github.com/LFDT-web3j